### PR TITLE
fix(c): add `LDFLAGS` automatically

### DIFF
--- a/extra/language/c.nix
+++ b/extra/language/c.nix
@@ -45,6 +45,10 @@ with lib;
           name = "LD_LIBRARY_PATH";
           prefix = "$DEVSHELL_DIR/lib";
         }
+        {
+          name = "LDFLAGS";
+          eval = "-L$DEVSHELL_DIR/lib";
+        }
       ])
       ++ lib.optionals hasIncludes [
         {


### PR DESCRIPTION
This env var fixes building `python-ldap` in a pdm python project when `openldap` is added to `language.c.libraries`.