### PR TITLE
feat: expose `lib` to allow easy composition

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -108,7 +108,7 @@
         default = toml;
       };
 
-      lib.importTOML = import ./nix/importTOML.nix;
+      lib = devshell;
 
       flakeModule = ./flake-module.nix;
     };


### PR DESCRIPTION
With this change, we can now use devshell like this:

```nix
{
  inputs = {
    devshell = {
      url = "github:numtide/devshell";
      inputs.nixpkgs.follows = "nixpkgs";
    };
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
  };

  outputs = {devshell, ...}: {
    devShells.x86_64-linux.default = devshell.lib.mkShell {};
  };
}
```

This makes it comfortable to use without flake parts. For instance, when composing with Blueprint it makes it easier to use a `devshell.nix` file without having to use overlays.